### PR TITLE
Implement remote rule providers and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 BOT_TOKEN=  # 你的 Telegram Bot Token
 GITHUB_TOKEN=  # 可选：提升 GitHub RAW 限速
 CACHE_TTL=600  # 规则与 Gist 缓存秒数
+SESSION_TTL=3600  # 会话过期秒数

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # telegram-clash-subBot
+
+This bot converts a Gist containing node lines into a Clash/Mihomo configuration with fine-grained routing rules. It is designed to run as a Telegram bot.
+
+## Prerequisites
+
+- Node.js 18+
+- npm
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+## Environment variables
+
+Create a `.env` file based on `.env.example` and fill in the values:
+
+- `BOT_TOKEN` – Telegram bot token.
+- `GITHUB_TOKEN` – Optional, increases GitHub raw rate limit.
+- `CACHE_TTL` – Cache time for fetched resources in seconds.
+- `SESSION_TTL` – How long a user session remains active without interaction.
+
+## Usage
+
+During development you can run:
+
+```bash
+npm run dev
+```
+
+Build and start for production:
+
+```bash
+npm run build
+npm start
+```
+
+Send a Gist raw link containing node definitions such as:
+
+```
+HK-BAGEHKL-VL-01=vless,bagehkl02.122733.xyz,12101,"e8194655-165d-4f54-aeca-ea27f63f81a1",transport=tcp,over-tls=true,skip-cert-verify=false,flow=xtls-rprx-vision,sni=www.msi.com,public-key="4SOnMHdgnsWC0ITUfqRyVDdV3Jc6pajuCPLsj_6trUg",short-id=39cd9d1aaa93e804,udp=true
+```
+
+Then choose rule sets via the inline keyboard. Rules are loaded remotely from [blackmatrix7/ios_rule_script](https://github.com/blackmatrix7/ios_rule_script/tree/master/rule/Clash).

--- a/src/alias.ts
+++ b/src/alias.ts
@@ -1,5 +1,5 @@
 export const alias: Record<string, string> = {
-      PrimeVideo: "AmazonPrimeVideo",
-        TikTok: "DouYin",
-          Copilot: "MicrosoftCopilot"
-          };
+  PrimeVideo: "AmazonPrimeVideo",
+  TikTok: "DouYin",
+  Copilot: "MicrosoftCopilot"
+};

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,12 +1,20 @@
-interface Entry<T> { ts: number; data: T }
+interface Entry<T> {
+  ts: number;
+  data: T;
+}
+
 export class Cache<T> {
-  constructor(private ttl = 600_000) {}   // 默认10分钟
+  constructor(private ttl = 600_000) {}
+
   private store = new Map<string, Entry<T>>();
+
   get(key: string) {
     const e = this.store.get(key);
     if (e && Date.now() - e.ts < this.ttl) return e.data;
-    this.store.delete(key); return undefined;
+    this.store.delete(key);
+    return undefined;
   }
+
   set(key: string, data: T) {
     this.store.set(key, { ts: Date.now(), data });
   }

--- a/src/gist.ts
+++ b/src/gist.ts
@@ -1,11 +1,18 @@
 import axios from "axios";
 
 export interface NodeMeta {
-  name: string; host: string; port: number; uuid: string;
-  params: Record<string, string>; region: string;
+  name: string;
+  host: string;
+  port: number;
+  uuid: string;
+  params: Record<string, string>;
+  region: string;
 }
 
-export async function fetchGistRaw(url: string, token?: string): Promise<string> {
+export async function fetchGistRaw(
+  url: string,
+  token?: string
+): Promise<string> {
   const rawUrl = url.includes("/raw")
     ? url
     : url.replace("gist.github.com", "gist.githubusercontent.com") + "/raw";
@@ -19,19 +26,19 @@ export async function fetchGistRaw(url: string, token?: string): Promise<string>
 export function parseNodeLine(line: string): NodeMeta {
   const [name, type, host, portStr, uuid, ...rest] = line.split(",");
   const params: Record<string, string> = {};
-  
-  // 直接遍历 rest 数组，不需要先 join 再 split
+
   rest.forEach(p => {
     const [k, v] = p.split("=");
     if (k && v) params[k.trim()] = v.replace(/"/g, "");
   });
-  
+
   const region = name.split("-")[0];
   return {
     name: name.trim(),
     host: host.trim(),
     port: Number(portStr),
     uuid: uuid.replace(/"/g, "").trim(),
-    params, region
+    params,
+    region
   };
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,15 +1,9 @@
-import axios from "axios";
 import { alias } from "./alias.js";
 
 const BASE =
   "https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/refs/heads/master/rule/Clash";
 
-export async function fetchRule(app: string, token?: string): Promise<string> {
+export function ruleUrl(app: string): string {
   const folder = alias[app] ?? app;
-  const url = `${BASE}/${folder}/${folder}.yaml`;
-  const { data } = await axios.get(url, {
-    headers: token ? { Authorization: `token ${token}` } : undefined,
-    timeout: 15000
-  });
-  return data as string;
+  return `${BASE}/${folder}/${folder}.yaml`;
 }

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,10 +1,11 @@
 import YAML from "yaml";
 import { NodeMeta } from "./gist.js";
+import { alias } from "./alias.js";
 
-export function buildYaml(
-  nodes: NodeMeta[],
-  rules: Record<string, string>
-): string {
+const BASE =
+  "https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/refs/heads/master/rule/Clash";
+
+export function buildYaml(nodes: NodeMeta[], apps: string[]): string {
   const proxies = nodes.map(n => ({
     name: n.name,
     type: "vless",
@@ -35,7 +36,7 @@ export function buildYaml(
     })),
     { name: "DIRECT", type: "direct" },
     { name: "REJECT", type: "reject" },
-    ...Object.keys(rules).map(app => ({
+    ...apps.map(app => ({
       name: `🎯 ${app}`,
       type: "select",
       proxies: ["♻️ Automatic", "DIRECT", "REJECT"]
@@ -43,13 +44,18 @@ export function buildYaml(
   ];
 
   const ruleProviders: Record<string, any> = {};
-  for (const [app, body] of Object.entries(rules)) {
-    ruleProviders[app] = { type: "inline", behavior: "domain", body };
+  for (const app of apps) {
+    const folder = alias[app] ?? app;
+    ruleProviders[app] = {
+      type: "http",
+      behavior: "domain",
+      url: `${BASE}/${folder}/${folder}.yaml`,
+      path: `./rules/${folder}.yaml`,
+      interval: 86400
+    };
   }
 
-  const ruleLines = Object.keys(rules).map(
-    app => `RULE-SET,${app},🎯 ${app}`
-  );
+  const ruleLines = apps.map(app => `RULE-SET,${app},🎯 ${app}`);
   ruleLines.push("MATCH,♻️ Automatic");
 
   return YAML.stringify({


### PR DESCRIPTION
## Summary
- document setup and usage in README
- add `SESSION_TTL` to env example
- clean up TypeScript formatting
- switch rule providers to remote URLs
- remove rule fetching/caching logic

## Testing
- `npm run build` *(fails: Cannot find module 'telegraf' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6845ac359be083209f4c6d52575eea1c