### PR TITLE
Add dynamic rule selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ HK-BAGEHKL-VL-01=vless,bagehkl02.122733.xyz,12101,"e8194655-165d-4f54-aeca-ea27f
 ```
 
 Then choose rule sets via the inline keyboard. Rules are loaded remotely from [blackmatrix7/ios_rule_script](https://github.com/blackmatrix7/ios_rule_script/tree/master/rule/Clash).
+
+The available categories are fetched dynamically from the repository at runtime. Use the "下一页" and "上一页" buttons to browse through all rule sets.

--- a/src/alias.ts
+++ b/src/alias.ts
@@ -1,5 +1,7 @@
 export const alias: Record<string, string> = {
   PrimeVideo: "AmazonPrimeVideo",
   TikTok: "DouYin",
-  Copilot: "MicrosoftCopilot"
+  Copilot: "MicrosoftCopilot",
+  ChatGPT: "OpenAI",
+  X: "Twitter"
 };

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,9 +1,13 @@
-import { alias } from "./alias.js";
+import axios from "axios";
 
-const BASE =
-  "https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/refs/heads/master/rule/Clash";
-
-export function ruleUrl(app: string): string {
-  const folder = alias[app] ?? app;
-  return `${BASE}/${folder}/${folder}.yaml`;
+export async function fetchRuleCategories(token?: string): Promise<string[]> {
+  const url = "https://api.github.com/repos/blackmatrix7/ios_rule_script/contents/rule/Clash?ref=master";
+  const { data } = await axios.get(url, {
+    headers: token ? { Authorization: `token ${token}` } : undefined,
+    timeout: 15000
+  });
+  return (data as any[])
+    .filter(item => item.type === "dir")
+    .map(item => item.name as string)
+    .sort();
 }


### PR DESCRIPTION
## Summary
- fetch rule categories from GitHub at startup
- paginate rule selection keyboard with next/prev
- note dynamic rule list in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845b0b1d7808320a43ee9d01d943382