### PR TITLE
Add search and custom group support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,17 @@ HK-01=vless,1478523.xyz,12101,"xxx",transport=tcp,over-tls=true,skip-cert-verify
 
 Then choose rule sets via the inline keyboard. Rules are loaded remotely from [blackmatrix7/ios_rule_script](https://github.com/blackmatrix7/ios_rule_script/tree/master/rule/Clash).
 
-The available categories are fetched dynamically from the repository at runtime. Use the "下一页" and "上一页" buttons to browse through all rule sets.
+The available categories are fetched dynamically from the repository at runtime. Use the "下一页" and "上一页" buttons to browse through all rule sets. You can press "🔍 搜索" and then send keywords to filter the list.
+
+### Custom groups
+
+Create a `groups.json` file in the project root to define groups of rule sets. Each key is the group name and its value is an array of category names. Selecting a group button toggles all rules inside it and the generated configuration will include those rule sets.
+
+Example `groups.json`:
+
+```json
+{
+  "Streaming": ["Netflix", "Disney", "YouTube"],
+  "Social": ["X", "Telegram"]
+}
+```

--- a/groups.json
+++ b/groups.json
@@ -1,0 +1,4 @@
+{
+  "Streaming": ["Netflix", "Disney", "YouTube"],
+  "Social": ["X", "Telegram"]
+}

--- a/src/groups.ts
+++ b/src/groups.ts
@@ -1,0 +1,19 @@
+import fs from "fs/promises";
+
+export async function loadGroups(
+  path = "groups.json"
+): Promise<Record<string, string[]>> {
+  try {
+    const data = await fs.readFile(path, "utf-8");
+    const obj = JSON.parse(data);
+    if (typeof obj !== "object" || obj === null) throw new Error("格式错误");
+    const result: Record<string, string[]> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (Array.isArray(v)) result[k] = v.map(s => String(s));
+    }
+    return result;
+  } catch (e: any) {
+    console.warn("未加载自定义分组", e.message);
+    return {};
+  }
+}


### PR DESCRIPTION
## Summary
- support keyword search for rule list and clear filter
- allow defining custom groups via `groups.json`
- expose new buttons for search and group toggling
- document custom groups in README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845bd24b33083208c149b1cc8a31a27