### PR TITLE
Fix pagination callback errors

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -159,19 +159,23 @@ bot.action(/TOGGLE_/, async ctx => {
 
 bot.action("NEXT", async ctx => {
   const session = getSession(ctx.from!.id);
-  if ((session.page + 1) * PAGE_SIZE < APP_LIST.length) session.page++;
-  await ctx.editMessageReplyMarkup({
-    inline_keyboard: buildKeyboard(session).reply_markup.inline_keyboard
-  });
+  if ((session.page + 1) * PAGE_SIZE < APP_LIST.length) {
+    session.page++;
+    await ctx.editMessageReplyMarkup({
+      inline_keyboard: buildKeyboard(session).reply_markup.inline_keyboard
+    });
+  }
   await ctx.answerCbQuery();
 });
 
 bot.action("PREV", async ctx => {
   const session = getSession(ctx.from!.id);
-  if (session.page > 0) session.page--;
-  await ctx.editMessageReplyMarkup({
-    inline_keyboard: buildKeyboard(session).reply_markup.inline_keyboard
-  });
+  if (session.page > 0) {
+    session.page--;
+    await ctx.editMessageReplyMarkup({
+      inline_keyboard: buildKeyboard(session).reply_markup.inline_keyboard
+    });
+  }
   await ctx.answerCbQuery();
 });
 
@@ -183,11 +187,13 @@ bot.action("SEARCH", async ctx => {
 
 bot.action("CLEAR_FILTER", async ctx => {
   const session = getSession(ctx.from!.id);
-  session.filter = undefined;
-  session.page = 0;
-  await ctx.editMessageReplyMarkup({
-    inline_keyboard: buildKeyboard(session).reply_markup.inline_keyboard
-  });
+  if (session.filter) {
+    session.filter = undefined;
+    session.page = 0;
+    await ctx.editMessageReplyMarkup({
+      inline_keyboard: buildKeyboard(session).reply_markup.inline_keyboard
+    });
+  }
   await ctx.answerCbQuery();
 });
 


### PR DESCRIPTION
## Summary
- only update reply markup when page or filter actually changes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845c2dfb9b08320964e1224fa6cf83f