### PR TITLE
Add /help command and improve rule selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ HK-01=vless,1478523.xyz,12101,"xxx",transport=tcp,over-tls=true,skip-cert-verify
 Then choose rule sets via the inline keyboard. Rules are loaded remotely from [blackmatrix7/ios_rule_script](https://github.com/blackmatrix7/ios_rule_script/tree/master/rule/Clash).
 
 The available categories are fetched dynamically from the repository at runtime. Use the "下一页" and "上一页" buttons to browse through all rule sets. You can press "🔍 搜索" and then send keywords to filter the list.
+You can also tap a letter button to quickly filter by the rule name's first letter.
+
+Send `/help` in the chat at any time to see all available commands.
 
 ### Custom groups
 


### PR DESCRIPTION
## Summary
- add a `/help` command listing basic operations
- support paginated group buttons and quick alphabet filters
- show letter filter buttons and add related handlers
- document `/help` and letter search in the README

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68465df3ad2083208a70cf692dea3645